### PR TITLE
Update hero intro to mention soccer instead of writing

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -8,7 +8,7 @@ export const site = {
   tagline: 'Software & ML engineer, occasional photographer.',
   // TODO: 1-2 sentence intro shown in the hero.
   intro:
-    'I build software and machine learning systems. Off the clock, I make photographs and write about what I learn.',
+    'I build software and machine learning systems. Off the clock, I make photographs and play soccer.',
   email: 'ojaswi.365@gmail.com',
   url: 'https://ojdh.github.io',
   location: 'Edmonton, Canada',


### PR DESCRIPTION
## Summary
- Swaps "write about what I learn" for "play soccer" in the homepage hero intro.

## Test plan
- [x] Text-only change, no build impact