### PR TITLE
Fix camping checklist: wire Supabase env vars into CI build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          PUBLIC_SUPABASE_URL: ${{ vars.PUBLIC_SUPABASE_URL }}
+          PUBLIC_SUPABASE_ANON_KEY: ${{ vars.PUBLIC_SUPABASE_ANON_KEY }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- The camping-2025 page's Supabase client was built with empty URL/key in CI, since the build runs in a clean environment with no access to the local `.env` (correctly gitignored). Every request silently failed, which surfaced as "wrong passcode" no matter what was typed.
- `PUBLIC_SUPABASE_URL` / `PUBLIC_SUPABASE_ANON_KEY` are now set as repo Actions variables and wired into the `Build` step's env.

## Test plan
- [ ] Merge this PR
- [ ] Confirm the `Build and Deploy` workflow run succeeds
- [ ] Visit https://ojdh.github.io/camping-2025 and confirm passcode `campfire2025` works