### PR TITLE
Let anyone remove an item from the camping checklist

### DIFF
--- a/src/components/TripChecklist.astro
+++ b/src/components/TripChecklist.astro
@@ -226,6 +226,15 @@
     await refreshAssignments();
   }
 
+  async function removeItem(item: Item) {
+    if (!client) return;
+    if (!confirm(`Remove "${item.name}"? This also clears anyone's claim on it.`)) return;
+    await client.from('items').delete().eq('id', item.id);
+    items = items.filter((i) => i.id !== item.id);
+    assignments = assignments.filter((a) => a.item_id !== item.id);
+    render();
+  }
+
   addItemForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     if (!client) return;
@@ -306,6 +315,14 @@
     nameSpan.className = 'text-[var(--color-ink)]';
     nameSpan.textContent = item.name;
     left.appendChild(nameSpan);
+
+    const removeItemBtn = document.createElement('button');
+    removeItemBtn.type = 'button';
+    removeItemBtn.textContent = 'remove';
+    removeItemBtn.title = 'Remove this item from the checklist';
+    removeItemBtn.className = 'text-xs text-[var(--color-muted)] underline decoration-dotted hover:text-[var(--color-accent)]';
+    removeItemBtn.addEventListener('click', () => removeItem(item));
+    left.appendChild(removeItemBtn);
 
     const itemAssignments = assignments.filter((a) => a.item_id === item.id);
     const myName = yourNameInput.value.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- Adds item-level delete (separate from the existing per-assignee unclaim) so people can remove items entirely, not just add them.
- Confirms before deleting, since removing an item clears everyone's claim on it via the `items` → `assignments` cascade delete.

## Test plan
- [x] Verified locally against the live Supabase project: added a throwaway test item, removed it, confirmed the confirm-dialog message and that only the test item disappeared — existing real claims (Oj, Sam) were untouched.
- [ ] Merge and spot-check on the live site.