### PR TITLE
Retro national-park badge theme for the camping checklist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.11",
         "@astrojs/sitemap": "^3.4.1",
+        "@fontsource-variable/fredoka": "^5.2.10",
         "@fontsource-variable/inter": "^5.2.5",
         "@fontsource/fraunces": "^5.2.5",
         "@supabase/supabase-js": "^2.110.7",
@@ -620,6 +621,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/fredoka": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/fredoka/-/fredoka-5.2.10.tgz",
+      "integrity": "sha512-W25a41EivYh8111C9x34ShRg+2kKGXnefg1Z9Zax5E0jOgOtGXn7UhoqVBvNLrJnWGv3hy8New0UiKDc/cYzPg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource-variable/inter": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.11",
     "@astrojs/sitemap": "^3.4.1",
+    "@fontsource-variable/fredoka": "^5.2.10",
     "@fontsource-variable/inter": "^5.2.5",
     "@fontsource/fraunces": "^5.2.5",
     "@supabase/supabase-js": "^2.110.7",

--- a/src/components/TripChecklist.astro
+++ b/src/components/TripChecklist.astro
@@ -1,116 +1,373 @@
 ---
 ---
 
-<div id="gate" class="mx-auto max-w-sm py-10 text-center">
-  <p class="text-[var(--color-muted)]">Enter the trip passcode to view and edit the checklist.</p>
-  <form id="gate-form" class="mt-4 flex gap-2">
+<div id="gate" class="camp-gate">
+  <p class="camp-gate__label">🔑 Enter the trip passcode to view and edit the checklist</p>
+  <form id="gate-form" class="camp-gate__form">
     <input
       type="password"
       id="gate-passcode"
       placeholder="Trip passcode"
       autocomplete="off"
-      class="flex-1 rounded-lg border border-[var(--color-faint)] bg-[var(--color-surface)] px-3 py-2 text-[var(--color-ink)]"
+      class="camp-input"
     />
-    <button
-      type="submit"
-      class="rounded-lg bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-white"
-    >
-      Enter
-    </button>
+    <button type="submit" class="camp-btn camp-btn--mustard">Enter</button>
   </form>
-  <p id="gate-error" class="mt-3 hidden text-sm text-[var(--color-accent)]"></p>
+  <p id="gate-error" class="camp-gate__error hidden"></p>
 </div>
 
 <div id="app" class="hidden">
-  <div class="flex flex-wrap items-center justify-between gap-3">
-    <div class="flex gap-2">
-      <button data-view="checklist" class="tab-btn" data-active="true">Checklist</button>
-      <button data-view="summary" class="tab-btn" data-active="false">Who's Bringing What</button>
+  <div class="camp-toolbar">
+    <div class="camp-tabs">
+      <button data-view="checklist" class="camp-tab" data-active="true">📋 Checklist</button>
+      <button data-view="summary" class="camp-tab" data-active="false">🎒 Who's Bringing What</button>
     </div>
-    <label class="flex items-center gap-2 text-sm text-[var(--color-muted)]">
+    <label class="camp-name-field">
       Your name
-      <input
-        id="your-name"
-        placeholder="e.g. Riza"
-        class="rounded-lg border border-[var(--color-faint)] bg-[var(--color-surface)] px-2.5 py-1.5 text-[var(--color-ink)]"
-      />
+      <input id="your-name" placeholder="e.g. Riza" class="camp-input camp-input--sm" />
     </label>
   </div>
 
-  <div id="view-checklist" class="mt-8 space-y-10">
+  <div id="view-checklist" class="mt-8 space-y-8">
     <div id="groups"></div>
 
-    <form id="add-item-form" class="flex flex-wrap items-end gap-3 border-t border-[var(--color-faint)] pt-6">
-      <div class="flex flex-col gap-1">
-        <label class="text-xs text-[var(--color-muted)]">Group</label>
-        <select
-          id="add-item-group"
-          class="rounded-lg border border-[var(--color-faint)] bg-[var(--color-surface)] px-2.5 py-1.5 text-sm text-[var(--color-ink)]"
-        >
-          <option>Camping Basics</option>
-          <option>Personal</option>
-          <option>Food</option>
-          <option>Cooking Gear</option>
-          <option>Misc.</option>
-        </select>
+    <form id="add-item-form" class="camp-add-form">
+      <p class="camp-add-form__heading">📝 Add something new</p>
+      <div class="camp-add-form__row">
+        <div class="camp-field">
+          <label class="camp-field__label">Group</label>
+          <select id="add-item-group" class="camp-input camp-input--sm">
+            <option>Camping Basics</option>
+            <option>Personal</option>
+            <option>Food</option>
+            <option>Cooking Gear</option>
+            <option>Misc.</option>
+          </select>
+        </div>
+        <div class="camp-field">
+          <label class="camp-field__label">Category</label>
+          <input
+            id="add-item-category"
+            list="category-options"
+            placeholder="e.g. Snacks"
+            class="camp-input camp-input--sm camp-input--w40"
+          />
+          <datalist id="category-options"></datalist>
+        </div>
+        <div class="camp-field camp-field--grow">
+          <label class="camp-field__label">Item name</label>
+          <input id="add-item-name" placeholder="e.g. Extra tarp" required class="camp-input camp-input--sm" />
+        </div>
+        <button type="submit" class="camp-btn camp-btn--mustard camp-btn--sm">Add item</button>
       </div>
-      <div class="flex flex-col gap-1">
-        <label class="text-xs text-[var(--color-muted)]">Category</label>
-        <input
-          id="add-item-category"
-          list="category-options"
-          placeholder="e.g. Snacks"
-          class="w-40 rounded-lg border border-[var(--color-faint)] bg-[var(--color-surface)] px-2.5 py-1.5 text-sm text-[var(--color-ink)]"
-        />
-        <datalist id="category-options"></datalist>
-      </div>
-      <div class="flex flex-1 flex-col gap-1">
-        <label class="text-xs text-[var(--color-muted)]">Item name</label>
-        <input
-          id="add-item-name"
-          placeholder="e.g. Extra tarp"
-          required
-          class="w-full rounded-lg border border-[var(--color-faint)] bg-[var(--color-surface)] px-2.5 py-1.5 text-sm text-[var(--color-ink)]"
-        />
-      </div>
-      <button
-        type="submit"
-        class="rounded-lg border border-[var(--color-faint)] px-3 py-1.5 text-sm font-medium text-[var(--color-ink)]"
-      >
-        Add item
-      </button>
     </form>
   </div>
 
   <div id="view-summary" class="mt-8 hidden space-y-6"></div>
 </div>
 
-<style>
-  .tab-btn {
-    border-radius: 9999px;
-    padding: 0.4rem 1rem;
+<style is:global>
+  .camp-gate {
+    max-width: 26rem;
+    margin: 0 auto;
+    padding: 2rem;
+    text-align: center;
+    background: var(--camp-card);
+    border: 3px solid var(--camp-forest);
+    border-radius: 1.25rem;
+    box-shadow: 5px 5px 0 var(--camp-forest);
+  }
+  .camp-gate__label {
+    font-family: var(--font-display);
+    font-weight: 600;
+    color: var(--camp-forest);
+  }
+  .camp-gate__form {
+    margin-top: 1rem;
+    display: flex;
+    gap: 0.5rem;
+  }
+  .camp-gate__error {
+    margin-top: 0.75rem;
     font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--color-muted);
+    font-weight: 600;
+    color: var(--camp-rust-deep);
   }
-  .tab-btn[data-active='true'] {
-    background: var(--color-accent-soft);
-    color: var(--color-accent);
+
+  .camp-input {
+    flex: 1;
+    border-radius: 0.75rem;
+    border: 2px solid var(--camp-forest);
+    background: var(--camp-card);
+    color: var(--camp-ink);
+    padding: 0.6rem 0.9rem;
   }
-  .chip {
+  .camp-input:focus {
+    outline: none;
+    border-color: var(--camp-mustard-deep);
+  }
+  .camp-input--sm {
+    padding: 0.4rem 0.7rem;
+    font-size: 0.875rem;
+    flex: initial;
+  }
+  .camp-input--w40 {
+    width: 10rem;
+  }
+
+  .camp-btn {
+    font-family: var(--font-display);
+    font-weight: 600;
+    white-space: nowrap;
+    border-radius: 9999px;
+    border: 2.5px solid var(--camp-forest);
+    padding: 0.6rem 1.4rem;
+    transition: transform 120ms ease, box-shadow 120ms ease;
+  }
+  .camp-btn:hover {
+    transform: translate(-2px, -2px);
+  }
+  .camp-btn:active {
+    transform: translate(1px, 1px);
+    box-shadow: none !important;
+  }
+  .camp-btn--mustard {
+    background: var(--camp-mustard);
+    color: var(--camp-forest-deep);
+    box-shadow: 4px 4px 0 var(--camp-forest);
+  }
+  .camp-btn--mustard:hover {
+    box-shadow: 6px 6px 0 var(--camp-forest);
+  }
+  .camp-btn--sm {
+    padding: 0.45rem 0.9rem;
+    font-size: 0.8rem;
+    box-shadow: 3px 3px 0 var(--camp-forest);
+  }
+  .camp-btn--sm:hover {
+    box-shadow: 5px 5px 0 var(--camp-forest);
+  }
+
+  .camp-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+  .camp-tabs {
+    display: flex;
+    gap: 0.6rem;
+  }
+  .camp-tab {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.9rem;
+    border-radius: 9999px;
+    padding: 0.5rem 1.1rem;
+    border: 2.5px solid var(--camp-forest);
+    color: var(--camp-forest);
+    background: transparent;
+    transition: transform 120ms ease;
+  }
+  .camp-tab:hover {
+    transform: translateY(-2px);
+  }
+  .camp-tab[data-active='true'] {
+    background: var(--camp-forest);
+    color: var(--camp-cream);
+    box-shadow: 3px 3px 0 var(--camp-rust);
+  }
+  .camp-name-field {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--camp-forest-deep);
+  }
+
+  .camp-group {
+    margin-top: 2rem;
+  }
+  .camp-group__badge {
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
-    border-radius: 9999px;
-    background: var(--color-accent-soft);
-    color: var(--color-accent);
-    font-size: 0.8rem;
-    padding: 0.2rem 0.6rem;
-  }
-  .chip button {
-    color: var(--color-accent);
+    gap: 0.5rem;
+    font-family: var(--font-display);
     font-weight: 600;
+    font-size: 1.35rem;
+    color: var(--camp-cream);
+    background: var(--camp-forest);
+    border-radius: 9999px;
+    padding: 0.5rem 1.25rem;
+    transform: rotate(-0.6deg);
+  }
+  .camp-group__icon {
+    font-size: 1.15rem;
+  }
+  .camp-category {
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--camp-mustard-deep);
+    border-bottom: 2px dashed var(--camp-mustard);
+    display: inline-block;
+    padding-bottom: 0.15rem;
+  }
+  .camp-trail {
+    margin-top: 1.5rem;
+    border: none;
+    border-top: 3px dashed var(--camp-forest);
+    opacity: 0.3;
+  }
+
+  .camp-item {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    background: var(--camp-card);
+    border: 2px dashed var(--camp-forest);
+    border-radius: 0.85rem;
+    padding: 0.65rem 0.9rem;
+    margin-top: 0.6rem;
+    transition: box-shadow 120ms ease, transform 120ms ease;
+  }
+  .camp-item:hover {
+    box-shadow: 3px 3px 0 var(--camp-mustard);
+    transform: translateY(-1px);
+  }
+  .camp-item__left {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .camp-item__name {
+    color: var(--camp-ink);
+    font-weight: 500;
+  }
+  .camp-item__remove {
+    font-size: 0.7rem;
+    color: var(--camp-forest-deep);
+    opacity: 0.35;
+    border-radius: 9999px;
+    padding: 0.1rem 0.4rem;
+  }
+  .camp-item__remove:hover {
+    opacity: 1;
+    color: var(--camp-rust-deep);
+    background: color-mix(in srgb, var(--camp-rust) 15%, transparent);
+  }
+
+  .camp-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    border-radius: 9999px;
+    background: var(--camp-rust);
+    color: var(--camp-cream);
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 0.2rem 0.65rem;
+    transform: rotate(var(--chip-rotate, -2deg));
+  }
+  .camp-chip button {
+    font-weight: 700;
     line-height: 1;
+  }
+  .camp-chip--new {
+    animation: camp-chip-pop 420ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+  @keyframes camp-chip-pop {
+    0% {
+      transform: scale(0) rotate(0deg);
+      opacity: 0;
+    }
+    60% {
+      transform: scale(1.2) rotate(-6deg);
+      opacity: 1;
+    }
+    100% {
+      transform: scale(1) rotate(var(--chip-rotate, -2deg));
+      opacity: 1;
+    }
+  }
+
+  .camp-claim-form {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .camp-claim-form input {
+    width: 7.5rem;
+  }
+
+  .camp-add-form {
+    border-top: 3px dashed var(--camp-forest);
+    padding-top: 1.5rem;
+  }
+  .camp-add-form__heading {
+    font-family: var(--font-display);
+    font-weight: 600;
+    color: var(--camp-forest);
+    margin-bottom: 0.75rem;
+  }
+  .camp-add-form__row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+    gap: 0.75rem;
+  }
+  .camp-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .camp-field--grow {
+    flex: 1;
+  }
+  .camp-field__label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--camp-forest-deep);
+    opacity: 0.7;
+  }
+
+  .camp-summary-person {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 1.2rem;
+    color: var(--camp-forest);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .camp-summary-list {
+    margin-top: 0.5rem;
+    padding-left: 0;
+  }
+  .camp-summary-list li {
+    list-style: none;
+    padding: 0.3rem 0;
+    padding-left: 1.4rem;
+    position: relative;
+    color: var(--camp-ink);
+  }
+  .camp-summary-list li::before {
+    content: '🥾';
+    position: absolute;
+    left: 0;
+    font-size: 0.8rem;
   }
 </style>
 
@@ -137,10 +394,23 @@
   }
 
   const NAME_STORAGE_KEY = 'camping-2025-name';
+  const GROUP_ORDER = ['Camping Basics', 'Personal', 'Food', 'Cooking Gear', 'Misc.'];
+  const GROUP_ICONS: Record<string, string> = {
+    'Camping Basics': '⛺',
+    Personal: '🧴',
+    Food: '🌮',
+    'Cooking Gear': '🔥',
+    'Misc.': '🎒',
+  };
+  const CATEGORY_ICONS: Record<string, string> = {
+    'Recreation / Fun': '🎲',
+  };
+  const SUMMARY_ICONS = ['🎒', '🥾', '🧭', '🔥', '🌲', '⭐'];
 
   let client: ReturnType<typeof createTripClient> | null = null;
   let items: Item[] = [];
   let assignments: Assignment[] = [];
+  let previousAssignmentIds = new Set<string>();
 
   const gate = document.getElementById('gate')!;
   const gateForm = document.getElementById('gate-form') as HTMLFormElement;
@@ -187,6 +457,7 @@
     const { data } = await client.from('assignments').select('*');
     assignments = (data as Assignment[]) ?? [];
     render();
+    previousAssignmentIds = new Set(assignments.map((a) => a.id));
   }
 
   function showApp() {
@@ -198,14 +469,14 @@
     e.preventDefault();
     const ok = await tryEnter(gatePasscodeInput.value);
     if (!ok) {
-      gateError.textContent = 'Wrong passcode — try again.';
+      gateError.textContent = '🚫 Wrong passcode — try again.';
       gateError.classList.remove('hidden');
     }
   });
 
-  document.querySelectorAll<HTMLButtonElement>('.tab-btn').forEach((btn) => {
+  document.querySelectorAll<HTMLButtonElement>('.camp-tab').forEach((btn) => {
     btn.addEventListener('click', () => {
-      document.querySelectorAll<HTMLButtonElement>('.tab-btn').forEach((b) => (b.dataset.active = 'false'));
+      document.querySelectorAll<HTMLButtonElement>('.camp-tab').forEach((b) => (b.dataset.active = 'false'));
       btn.dataset.active = 'true';
       const view = btn.dataset.view;
       viewChecklist.classList.toggle('hidden', view !== 'checklist');
@@ -224,6 +495,15 @@
     if (!client) return;
     await client.from('assignments').delete().eq('id', assignmentId);
     await refreshAssignments();
+  }
+
+  async function removeItem(item: Item) {
+    if (!client) return;
+    if (!confirm(`Remove "${item.name}"? This also clears anyone's claim on it.`)) return;
+    await client.from('items').delete().eq('id', item.id);
+    items = items.filter((i) => i.id !== item.id);
+    assignments = assignments.filter((a) => a.item_id !== item.id);
+    render();
   }
 
   addItemForm.addEventListener('submit', async (e) => {
@@ -262,17 +542,20 @@
 
   function renderChecklist() {
     groupsEl.innerHTML = '';
-    const groupOrder = ['Camping Basics', 'Personal', 'Food', 'Cooking Gear', 'Misc.'];
     const groupNames = Array.from(new Set(items.map((i) => i.group_name))).sort(
-      (a, b) => groupOrder.indexOf(a) - groupOrder.indexOf(b)
+      (a, b) => GROUP_ORDER.indexOf(a) - GROUP_ORDER.indexOf(b)
     );
 
-    for (const groupName of groupNames) {
+    groupNames.forEach((groupName, groupIndex) => {
+      if (groupIndex > 0) groupsEl.appendChild(document.createElement('hr')).className = 'camp-trail';
+
       const groupItems = items.filter((i) => i.group_name === groupName);
       const groupSection = document.createElement('section');
+      groupSection.className = 'camp-group';
+
       const heading = document.createElement('h2');
-      heading.className = 'font-serif text-2xl font-semibold text-[var(--color-ink)]';
-      heading.textContent = groupName;
+      heading.className = 'camp-group__badge';
+      heading.innerHTML = `<span class="camp-group__icon">${GROUP_ICONS[groupName] ?? '🏕️'}</span> ${escapeHtml(groupName)}`;
       groupSection.appendChild(heading);
 
       const categories = Array.from(new Set(groupItems.map((i) => i.category)));
@@ -280,38 +563,48 @@
         const categoryItems = groupItems.filter((i) => i.category === category);
         if (category !== groupName) {
           const catHeading = document.createElement('h3');
-          catHeading.className = 'mt-5 text-sm font-semibold uppercase tracking-wide text-[var(--color-muted)]';
-          catHeading.textContent = category;
+          catHeading.className = 'camp-category';
+          catHeading.textContent = `${CATEGORY_ICONS[category] ?? ''} ${category}`.trim();
           groupSection.appendChild(catHeading);
         }
         const list = document.createElement('ul');
-        list.className = 'mt-3 divide-y divide-[var(--color-faint)]';
+        list.className = 'space-y-0';
         for (const item of categoryItems) {
           list.appendChild(renderItemRow(item));
         }
         groupSection.appendChild(list);
       }
       groupsEl.appendChild(groupSection);
-    }
+    });
   }
 
   function renderItemRow(item: Item): HTMLLIElement {
     const li = document.createElement('li');
-    li.className = 'flex flex-wrap items-center justify-between gap-2 py-3';
+    li.className = 'camp-item';
 
     const left = document.createElement('div');
-    left.className = 'flex flex-wrap items-center gap-2';
+    left.className = 'camp-item__left';
 
     const nameSpan = document.createElement('span');
-    nameSpan.className = 'text-[var(--color-ink)]';
+    nameSpan.className = 'camp-item__name';
     nameSpan.textContent = item.name;
     left.appendChild(nameSpan);
 
+    const removeItemBtn = document.createElement('button');
+    removeItemBtn.type = 'button';
+    removeItemBtn.textContent = '✕';
+    removeItemBtn.title = 'Remove this item from the checklist';
+    removeItemBtn.className = 'camp-item__remove';
+    removeItemBtn.addEventListener('click', () => removeItem(item));
+    left.appendChild(removeItemBtn);
+
     const itemAssignments = assignments.filter((a) => a.item_id === item.id);
     const myName = yourNameInput.value.trim().toLowerCase();
-    for (const a of itemAssignments) {
+    itemAssignments.forEach((a, index) => {
       const chip = document.createElement('span');
-      chip.className = 'chip';
+      chip.className = 'camp-chip';
+      chip.style.setProperty('--chip-rotate', index % 2 === 0 ? '-2deg' : '2deg');
+      if (!previousAssignmentIds.has(a.id)) chip.classList.add('camp-chip--new');
       chip.textContent = a.person_name + (a.note ? ` — ${a.note}` : '');
       if (a.person_name.trim().toLowerCase() === myName) {
         const removeBtn = document.createElement('button');
@@ -321,10 +614,10 @@
         chip.appendChild(removeBtn);
       }
       left.appendChild(chip);
-    }
+    });
 
     const right = document.createElement('form');
-    right.className = 'flex items-center gap-1.5';
+    right.className = 'camp-claim-form';
     right.addEventListener('submit', (e) => {
       e.preventDefault();
       claimItem(item.id, noteInput.value.trim());
@@ -332,12 +625,11 @@
     });
     const noteInput = document.createElement('input');
     noteInput.placeholder = 'note (optional)';
-    noteInput.className =
-      'w-28 rounded-lg border border-[var(--color-faint)] bg-[var(--color-surface)] px-2 py-1 text-xs text-[var(--color-ink)]';
+    noteInput.className = 'camp-input camp-input--sm';
     const claimBtn = document.createElement('button');
     claimBtn.type = 'submit';
-    claimBtn.textContent = "I'll bring this";
-    claimBtn.className = 'whitespace-nowrap rounded-lg border border-[var(--color-faint)] px-2.5 py-1 text-xs font-medium text-[var(--color-ink)]';
+    claimBtn.textContent = "🙋 I'll bring this";
+    claimBtn.className = 'camp-btn camp-btn--mustard camp-btn--sm';
     right.appendChild(noteInput);
     right.appendChild(claimBtn);
 
@@ -357,25 +649,28 @@
       byPerson.set(a.person_name, list);
     }
     if (byPerson.size === 0) {
-      viewSummary.innerHTML = '<p class="text-[var(--color-muted)]">Nobody has claimed anything yet.</p>';
+      viewSummary.innerHTML =
+        '<p class="text-[var(--camp-forest-deep)]">🌲 Nobody has claimed anything yet.</p>';
       return;
     }
-    for (const [person, claimed] of Array.from(byPerson.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
-      const section = document.createElement('div');
-      const heading = document.createElement('h3');
-      heading.className = 'font-serif text-xl font-semibold text-[var(--color-ink)]';
-      heading.textContent = person;
-      section.appendChild(heading);
-      const list = document.createElement('ul');
-      list.className = 'mt-2 list-inside list-disc text-[var(--color-ink)]';
-      for (const c of claimed) {
-        const li = document.createElement('li');
-        li.textContent = c.itemName + (c.note ? ` — ${c.note}` : '');
-        list.appendChild(li);
-      }
-      section.appendChild(list);
-      viewSummary.appendChild(section);
-    }
+    Array.from(byPerson.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .forEach(([person, claimed], index) => {
+        const section = document.createElement('div');
+        const heading = document.createElement('h3');
+        heading.className = 'camp-summary-person';
+        heading.textContent = `${SUMMARY_ICONS[index % SUMMARY_ICONS.length]} ${person}`;
+        section.appendChild(heading);
+        const list = document.createElement('ul');
+        list.className = 'camp-summary-list';
+        for (const c of claimed) {
+          const li = document.createElement('li');
+          li.textContent = c.itemName + (c.note ? ` — ${c.note}` : '');
+          list.appendChild(li);
+        }
+        section.appendChild(list);
+        viewSummary.appendChild(section);
+      });
   }
 
   // Auto-enter if a passcode is already stored from a previous visit.

--- a/src/pages/camping-2025.astro
+++ b/src/pages/camping-2025.astro
@@ -1,19 +1,71 @@
 ---
+import '@fontsource-variable/fredoka';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import TripChecklist from '../components/TripChecklist.astro';
 ---
 
 <BaseLayout title="Camping 2025" description="Who's bringing what for the 2025 camping trip.">
-  <section class="mx-auto max-w-3xl px-6 py-16">
-    <h1 class="font-serif text-4xl font-semibold tracking-tight text-[var(--color-ink)]">
-      Camping 2025 Checklist
-    </h1>
-    <p class="mt-4 max-w-xl leading-relaxed text-[var(--color-muted)]">
-      Claim what you're bringing, or see who's got what covered.
-    </p>
+  <section class="camp-theme px-6 py-16">
+    <div class="mx-auto max-w-3xl">
+      <div class="camp-badge" aria-hidden="true">🏕️</div>
+      <h1 class="camp-title">Camping 2025</h1>
+      <p class="camp-tagline">Claim what you're bringing, or see who's got what covered.</p>
 
-    <div class="mt-10">
-      <TripChecklist />
+      <div class="mt-10">
+        <TripChecklist />
+      </div>
     </div>
   </section>
 </BaseLayout>
+
+<style>
+  .camp-theme {
+    --camp-forest: #2f5233;
+    --camp-forest-deep: #1e3a22;
+    --camp-cream: #fbf1de;
+    --camp-card: #fffaf0;
+    --camp-mustard: #e0a83c;
+    --camp-mustard-deep: #b8822a;
+    --camp-rust: #c1502e;
+    --camp-rust-deep: #8f3a20;
+    --camp-ink: #2b2117;
+    --font-display: 'Fredoka Variable', ui-rounded, sans-serif;
+
+    background: var(--camp-cream);
+    min-height: 100vh;
+  }
+
+  .camp-badge {
+    width: 5.5rem;
+    height: 5.5rem;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2.75rem;
+    background: var(--camp-mustard);
+    border: 3px dashed var(--camp-forest);
+    border-radius: 9999px;
+    box-shadow: 4px 4px 0 var(--camp-forest);
+  }
+
+  .camp-title {
+    margin-top: 1.25rem;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 2.75rem;
+    text-align: center;
+    letter-spacing: 0.02em;
+    color: var(--camp-forest);
+    transform: rotate(-1.5deg);
+  }
+
+  .camp-tagline {
+    margin-top: 0.75rem;
+    max-width: 32rem;
+    margin-inline: auto;
+    text-align: center;
+    color: var(--camp-forest-deep);
+    opacity: 0.75;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Full visual facelift for `/camping-2025`: forest green / mustard / burnt-orange retro badge palette, Fredoka display font, circular logo badge, trail-sign-style group headers with per-category emoji, dashed section dividers, ticket-style item cards, tilted stamp-style assignee chips with a pop-in animation on claim, and sticker buttons (offset shadow, press-down on click).
- Scoped entirely to this page/component — no changes to the shared site theme, header, footer, or other pages.

## Test plan
- [x] Verified locally against the live Supabase project: passcode gate, claim, unclaim, add item, remove item (with confirm dialog), summary view — all work with the new theme, zero console errors.
- [x] Confirmed real data (Oj's and Sam's actual claims) untouched after testing with throwaway items only.
- [x] `npm run build` succeeds.
- [ ] Merge and eyeball it live.